### PR TITLE
[#5] Accept float values in ExifValue constructor

### DIFF
--- a/src/Record/ExifList.php
+++ b/src/Record/ExifList.php
@@ -73,7 +73,7 @@ final readonly class ExifList implements \Countable, \IteratorAggregate, \String
     }
 
     /**
-     * @return list<int|string|ExifValueList|ExifValueMap>
+     * @return list<int|float|string|ExifValueList|ExifValueMap>
      */
     public function toArray(): array
     {

--- a/src/Record/ExifMap.php
+++ b/src/Record/ExifMap.php
@@ -29,7 +29,7 @@ final class ExifMap implements \Countable, \IteratorAggregate, \Stringable
     private ?GpsValue $gps = null;
 
     /**
-     * @param array<int|string, int|string|ExifValueList|ExifValueMap> $values
+     * @param array<int|string, int|float|string|ExifValueList|ExifValueMap> $values
      */
     public function __construct(array $values)
     {
@@ -138,7 +138,7 @@ final class ExifMap implements \Countable, \IteratorAggregate, \Stringable
     }
 
     /**
-     * @return array<string, int|string|ExifValueList|ExifValueMap>
+     * @return array<string, int|float|string|ExifValueList|ExifValueMap>
      */
     public function toArray(): array
     {

--- a/src/Record/ExifValue.php
+++ b/src/Record/ExifValue.php
@@ -7,6 +7,7 @@ use OneToMany\ExifTools\Exception\LogicException;
 use function array_is_list;
 use function ctype_digit;
 use function explode;
+use function is_float;
 use function is_int;
 use function is_numeric;
 use function is_string;
@@ -16,17 +17,17 @@ use function substr_count;
 use function trim;
 
 /**
- * @phpstan-type ExifValueList list<int|string>
- * @phpstan-type ExifValueMap array<string, int|string>
+ * @phpstan-type ExifValueList list<int|float|string>
+ * @phpstan-type ExifValueMap array<string, int|float|string>
  */
 final readonly class ExifValue implements \Stringable
 {
-    private int|string|ExifList|ExifMap $value;
+    private int|float|string|ExifList|ExifMap $value;
 
     /**
-     * @param int|string|ExifValueList|ExifValueMap $value
+     * @param int|float|string|ExifValueList|ExifValueMap $value
      */
-    public function __construct(int|string|array $value)
+    public function __construct(int|float|string|array $value)
     {
         $this->value = $this->clean($value);
     }
@@ -36,15 +37,15 @@ final readonly class ExifValue implements \Stringable
         return (string) $this->value;
     }
 
-    public function get(): int|string|ExifList|ExifMap
+    public function get(): int|float|string|ExifList|ExifMap
     {
         return $this->value;
     }
 
     /**
-     * @return int|string|ExifValueList|ExifValueMap
+     * @return int|float|string|ExifValueList|ExifValueMap
      */
-    public function value(): int|string|array
+    public function value(): int|float|string|array
     {
         if ($this->isList() || $this->isMap()) {
             return $this->value->toArray(); // @phpstan-ignore-line
@@ -61,6 +62,16 @@ final readonly class ExifValue implements \Stringable
     public function isInt(): bool
     {
         return is_int($this->value);
+    }
+
+    /**
+     * @phpstan-assert-if-true float $this->get()
+     * @phpstan-assert-if-true float $this->value()
+     * @phpstan-assert-if-true float $this->value
+     */
+    public function isFloat(): bool
+    {
+        return is_float($this->value);
     }
 
     /**
@@ -98,12 +109,16 @@ final readonly class ExifValue implements \Stringable
      * a floating point number. EXIF encodes decimals as a fraction (ex: "3930/100"),
      * so the fractional components are extracted, divided, and returned as a float.
      *
-     * @throws LogicException if the value is not an integer or string
+     * @throws LogicException if the value is not a scalar
      */
     public function toFloat(): ?float
     {
         if ($this->isList() || $this->isMap()) {
             throw new LogicException('Lists and maps cannot be converted to floating point numbers.');
+        }
+
+        if ($this->isFloat()) {
+            return $this->value;
         }
 
         if ($this->isInt()) {
@@ -156,10 +171,14 @@ final readonly class ExifValue implements \Stringable
     }
 
     /**
-     * @param int|string|ExifValueList|ExifValueMap $value
+     * @param int|float|string|ExifValueList|ExifValueMap $value
      */
-    private function clean(int|string|array $value): int|string|ExifList|ExifMap
+    private function clean(int|float|string|array $value): int|float|string|ExifList|ExifMap
     {
+        if (is_float($value)) {
+            return $value;
+        }
+
         if (is_int($value)) {
             return $value;
         }

--- a/tests/Record/ExifValueTest.php
+++ b/tests/Record/ExifValueTest.php
@@ -25,13 +25,13 @@ final class ExifValueTest extends TestCase
     }
 
     #[DataProvider('providerToFloatValues')]
-    public function testToFloatReturnsExpected(int|string $value, ?float $expected): void
+    public function testToFloatReturnsExpected(int|float|string $value, ?float $expected): void
     {
-        $this->assertSame($expected, new ExifValue($value)->toFloat());
+        $this->assertSame($expected, (new ExifValue($value))->toFloat());
     }
 
     /**
-     * @return list<array{0: int|string, 1: ?float}>
+     * @return list<array{0: int|float|string, 1: ?float}>
      */
     public static function providerToFloatValues(): array
     {
@@ -47,7 +47,24 @@ final class ExifValueTest extends TestCase
             ['0/0', null],
             ['', null],
             ['not-a-number', null],
+            [39.3, 39.3],
+            [-179.5, -179.5],
         ];
+    }
+
+    public function testFloatValueIsStoredNatively(): void
+    {
+        $exifValue = new ExifValue(39.3);
+
+        $this->assertTrue($exifValue->isFloat());
+        $this->assertSame(39.3, $exifValue->value());
+    }
+
+    public function testFloatValuePreservesPrecision(): void
+    {
+        $exifValue = new ExifValue(-179.89999389648438);
+
+        $this->assertSame(-179.89999389648438, $exifValue->toFloat());
     }
 
     public function testToTimestampRequiresIntegerOrString(): void


### PR DESCRIPTION
## Summary

Fixes #5.

PHP's `exif_read_data()` can return `float` values for certain EXIF tags (e.g. `GPSAltitude`). Currently, `ExifValue` only accepts `int|string|array`, which causes an implicit float-to-int conversion warning on PHP 8.1+.

This PR adds native float support throughout the value chain:

- Widens `ExifValue` property, constructor, `get()`, `value()`, and `clean()` to accept and store `float`
- Adds `isFloat()` type-checking method (consistent with `isInt()`, `isString()`, etc.)
- `toFloat()` returns native floats directly — no conversion, full precision preserved
- Updates phpstan type aliases (`ExifValueList`, `ExifValueMap`) to include `float`
- Updates `toArray()` return types on `ExifList` and `ExifMap`
- Updates `ExifMap` constructor phpdoc

All existing tests pass. phpstan reports 0 errors.

## Test plan

- [x] `testFloatValueIsStoredNatively` — verifies `isFloat()` and `value()` on float input
- [x] `testFloatValuePreservesPrecision` — verifies `-179.89999389648438` survives roundtrip via `toFloat()`
- [x] Float values added to `providerToFloatValues` data provider
- [x] All 46 tests passing
- [x] phpstan clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)